### PR TITLE
Add specialised exception to indicate token is expired

### DIFF
--- a/src/main/java/com/macasaet/fernet/Token.java
+++ b/src/main/java/com/macasaet/fernet/Token.java
@@ -169,7 +169,7 @@ public class Token {
         if (getVersion() != (byte) 0x80) {
             throw new TokenValidationException("Invalid version");
         } else if (!getTimestamp().isAfter(earliestValidInstant)) {
-            throw new TokenValidationException("Token is expired");
+            throw new TokenExpiredException("Token is expired");
         } else if (!getTimestamp().isBefore(latestValidInstant)) {
             throw new TokenValidationException("Token timestamp is in the future (clock skew).");
         } else if (!isValidSignature(key)) {

--- a/src/main/java/com/macasaet/fernet/TokenExpiredException.java
+++ b/src/main/java/com/macasaet/fernet/TokenExpiredException.java
@@ -1,0 +1,33 @@
+package com.macasaet.fernet;
+
+/**
+ * This is a special case of the {@link TokenValidationException} that indicates that the Fernet token is invalid
+ * because the application-defined time-to-live has elapsed. Applications can use this to communicate to the client that
+ * a new Fernet must be generated, possibly by re-authenticating.
+ *
+ * <p>Copyright &copy; 2017 Carlos Macasaet.</p>
+ *
+ * @author Carlos Macasaet
+ */
+public class TokenExpiredException extends TokenValidationException {
+
+    private static final long serialVersionUID = -434587659069852734L;
+
+    public TokenExpiredException(final String message) {
+        super(message);
+    }
+
+    public TokenExpiredException(final Throwable cause) {
+        this(cause.getMessage(), cause);
+    }
+
+    public TokenExpiredException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+    public TokenExpiredException(final String message, final Throwable cause, final boolean enableSuppression,
+            final boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+
+}


### PR DESCRIPTION
This change allows for specific behaviour in the case a token is
expired.

Resolves: #9