### PR TITLE
Support JDK 10 and 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@
 
 language: java
 jdk:
-- oraclejdk8
-- openjdk8
+  - openjdk8
+  - openjdk10
+  - openjdk11
 dist: trusty
 script: mvn org.jacoco:jacoco-maven-plugin:prepare-agent clean install sonar:sonar site
 env:

--- a/fernet-aws-secrets-manager-rotator/pom.xml
+++ b/fernet-aws-secrets-manager-rotator/pom.xml
@@ -139,6 +139,10 @@
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-xray-recorder-sdk-aws-sdk</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
   </dependencies>
   <distributionManagement>
     <site>

--- a/fernet-jersey-auth/pom.xml
+++ b/fernet-jersey-auth/pom.xml
@@ -84,6 +84,11 @@
         <artifactId>mockito-core</artifactId>
         <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <distributionManagement>
     <site>

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,11 @@
           <version>2.27.0</version>
           <scope>test</scope>
       </dependency>
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>2.4.0-b180830.0359</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <build>


### PR DESCRIPTION
This PR builds the libraries using JDK 10 and 11 in addition to JDK 8. The compiler source and targets are still set to 1.8.