### PR TITLE
Clean Secret Data from Memory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ jdk:
   - openjdk8
   - openjdk10
   - openjdk11
-dist: trusty
+dist: xenial
 script: mvn org.jacoco:jacoco-maven-plugin:prepare-agent clean install sonar:sonar site
 env:
   matrix:

--- a/fernet-aws-secrets-manager-rotator/src/main/java/com/macasaet/fernet/aws/secretsmanager/rotation/AbstractFernetKeyRotator.java
+++ b/fernet-aws-secrets-manager-rotator/src/main/java/com/macasaet/fernet/aws/secretsmanager/rotation/AbstractFernetKeyRotator.java
@@ -21,6 +21,7 @@ import static com.macasaet.fernet.aws.secretsmanager.rotation.Stage.PENDING;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 import java.util.Collection;
@@ -244,7 +245,7 @@ abstract class AbstractFernetKeyRotator implements RequestStreamHandler {
      * @param secret secret data that is no longer needed
      */
     protected void wipe(final ByteBuffer secret) {
-        secret.clear();
+        ((Buffer)secret).clear();
         final byte[] random = new byte[secret.capacity()];
         getRandom().nextBytes(random);
         secret.put(random);

--- a/fernet-aws-secrets-manager-rotator/src/main/java/com/macasaet/fernet/aws/secretsmanager/rotation/AbstractFernetKeyRotator.java
+++ b/fernet-aws-secrets-manager-rotator/src/main/java/com/macasaet/fernet/aws/secretsmanager/rotation/AbstractFernetKeyRotator.java
@@ -86,12 +86,23 @@ abstract class AbstractFernetKeyRotator implements RequestStreamHandler {
         this.random = random;
     }
 
+    @SuppressWarnings("PMD.DoNotCallGarbageCollectionExplicitly")
     public void handleRequest(final InputStream input, final OutputStream output, final Context context) throws IOException {
         final RotationRequest request = getMapper().readValue(input, RotationRequest.class);
         getLogger().debug("Processing request: {}", request);
-        seed();
 
         handleRotationRequest(request);
+
+        // Since performance is not a concern for this Lambda, recommend that the JVM reclaim memory that may contain
+        // secret data.
+        System.gc();
+    }
+
+    protected void finalize() throws Throwable {
+        getKms().shutdown();
+        getSecretsManager().shutdown();
+
+        super.finalize();
     }
 
     protected void handleRotationRequest(final RotationRequest request) {
@@ -218,6 +229,27 @@ abstract class AbstractFernetKeyRotator implements RequestStreamHandler {
         }
     }
 
+    /**
+     * Overwrite the data in the byte array prior to returning memory to the system.
+     *
+     * @param secretBytes secret data that is no longer needed
+     */
+    protected void wipe(final byte[] secretBytes) {
+        getRandom().nextBytes(secretBytes);
+    }
+
+    /**
+     * Overwrite the data in the byte buffer prior to returning memory to the system.
+     *
+     * @param secret secret data that is no longer needed
+     */
+    protected void wipe(final ByteBuffer secret) {
+        secret.clear();
+        final byte[] random = new byte[secret.capacity()];
+        getRandom().nextBytes(random);
+        secret.put(random);
+    }
+
     protected SecretsManager getSecretsManager() {
         return secretsManager;
     }
@@ -227,6 +259,7 @@ abstract class AbstractFernetKeyRotator implements RequestStreamHandler {
     }
 
     protected Random getRandom() {
+        seed();
         return random;
     }
 

--- a/fernet-aws-secrets-manager-rotator/src/main/java/com/macasaet/fernet/aws/secretsmanager/rotation/MemoryOverwritingRequestHandler.java
+++ b/fernet-aws-secrets-manager-rotator/src/main/java/com/macasaet/fernet/aws/secretsmanager/rotation/MemoryOverwritingRequestHandler.java
@@ -15,6 +15,7 @@
  */
 package com.macasaet.fernet.aws.secretsmanager.rotation;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.Random;
 
@@ -65,7 +66,7 @@ class MemoryOverwritingRequestHandler extends RequestHandler2 {
         final ByteBuffer buffer = putRequest.getSecretBinary();
         final byte[] bytes = new byte[buffer.capacity()];
         getRandom().nextBytes(bytes);
-        buffer.clear();
+        ((Buffer)buffer).clear();
         buffer.put(bytes);
     }
 

--- a/fernet-aws-secrets-manager-rotator/src/main/java/com/macasaet/fernet/aws/secretsmanager/rotation/MemoryOverwritingRequestHandler.java
+++ b/fernet-aws-secrets-manager-rotator/src/main/java/com/macasaet/fernet/aws/secretsmanager/rotation/MemoryOverwritingRequestHandler.java
@@ -1,0 +1,76 @@
+/**
+   Copyright 2019 Carlos Macasaet
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package com.macasaet.fernet.aws.secretsmanager.rotation;
+
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+import com.amazonaws.Request;
+import com.amazonaws.Response;
+import com.amazonaws.handlers.RequestHandler2;
+import com.amazonaws.services.secretsmanager.model.PutSecretValueRequest;
+
+/**
+ * This request handler makes a best effort to clear out sensitive data that was submitted to the AWS SDK after any
+ * response or error. The scope is limited to request objects. It does not account for any copies that may have been
+ * made by the SDK (e.g. by the marshalling process) nor any copies made by the JVM.
+ *
+ * <p>Copyright &copy; 2019 Carlos Macasaet.</p>
+ *
+ * @author Carlos Macasaet
+ */
+class MemoryOverwritingRequestHandler extends RequestHandler2 {
+
+    private final Random random;
+
+    public MemoryOverwritingRequestHandler(final Random random) {
+        super();
+        if (random == null) {
+            throw new IllegalArgumentException("random cannot be null");
+        }
+        this.random = random;
+    }
+
+    public void afterResponse(final Request<?> request, final Response<?> response) {
+        final Object requestObject = request.getOriginalRequestObject();
+        if (requestObject instanceof PutSecretValueRequest) {
+            final PutSecretValueRequest putRequest = (PutSecretValueRequest) requestObject;
+            overwriteSecret(putRequest);
+        }
+    }
+
+    public void afterError(final Request<?> request, final Response<?> response, final Exception exception) {
+        final Object requestObject = request.getOriginalRequestObject();
+        if (requestObject instanceof PutSecretValueRequest) {
+            final PutSecretValueRequest putRequest = (PutSecretValueRequest) requestObject;
+            overwriteSecret(putRequest);
+        }
+    }
+
+    @SuppressWarnings("PMD.LawOfDemeter")
+    protected void overwriteSecret(final PutSecretValueRequest putRequest) {
+        final ByteBuffer buffer = putRequest.getSecretBinary();
+        final byte[] bytes = new byte[buffer.capacity()];
+        getRandom().nextBytes(bytes);
+        buffer.clear();
+        buffer.put(bytes);
+    }
+
+    protected Random getRandom() {
+        return random;
+    }
+
+}

--- a/fernet-aws-secrets-manager-rotator/src/test/java/com/macasaet/fernet/aws/secretsmanager/rotation/MultiFernetKeyRotatorTest.java
+++ b/fernet-aws-secrets-manager-rotator/src/test/java/com/macasaet/fernet/aws/secretsmanager/rotation/MultiFernetKeyRotatorTest.java
@@ -20,8 +20,10 @@ import static com.macasaet.fernet.aws.secretsmanager.rotation.Stage.PENDING;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -44,6 +46,8 @@ import org.mockito.Mock;
 import org.mockito.Spy;
 
 import com.amazonaws.services.kms.AWSKMS;
+import com.amazonaws.services.kms.model.GenerateRandomRequest;
+import com.amazonaws.services.kms.model.GenerateRandomResult;
 import com.macasaet.fernet.Key;
 
 /**
@@ -71,6 +75,10 @@ public class MultiFernetKeyRotatorTest {
     public void setUp() throws Exception {
         initMocks(this);
         rotator.setMaxActiveKeys(2);
+
+        final GenerateRandomResult value = mock(GenerateRandomResult.class);
+        given(value.getPlaintext()).willReturn(ByteBuffer.allocate(1024));
+        given(kms.generateRandom(any(GenerateRandomRequest.class))).willReturn(value);
     }
 
     @After

--- a/fernet-aws-secrets-manager-rotator/src/test/java/com/macasaet/fernet/aws/secretsmanager/rotation/SecretsManagerTest.java
+++ b/fernet-aws-secrets-manager-rotator/src/test/java/com/macasaet/fernet/aws/secretsmanager/rotation/SecretsManagerTest.java
@@ -45,6 +45,9 @@ import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import com.amazonaws.AmazonWebServiceRequest;
+import com.amazonaws.DefaultRequest;
+import com.amazonaws.Request;
 import com.amazonaws.services.secretsmanager.AWSSecretsManager;
 import com.amazonaws.services.secretsmanager.model.DescribeSecretRequest;
 import com.amazonaws.services.secretsmanager.model.DescribeSecretResult;
@@ -53,7 +56,10 @@ import com.amazonaws.services.secretsmanager.model.GetSecretValueResult;
 import com.amazonaws.services.secretsmanager.model.PutSecretValueRequest;
 import com.amazonaws.services.secretsmanager.model.ResourceNotFoundException;
 import com.amazonaws.services.secretsmanager.model.UpdateSecretVersionStageRequest;
+import com.amazonaws.xray.AWSXRayRecorder;
+import com.amazonaws.xray.handlers.TracingHandler;
 import com.macasaet.fernet.Key;
+import com.macasaet.fernet.aws.secretsmanager.rotation.SecretsManager.EphemeralPutSecretValueRequest;
 
 /**
  * <p>Copyright &copy; 2018 Carlos Macasaet.</p>
@@ -230,6 +236,20 @@ public class SecretsManagerTest {
         request.setVersionStages(singleton("AWSPREVIOUS"));
         request.setSecretBinary(ByteBuffer.wrap((expected + expected).getBytes("UTF-8")));
         verify(delegate).putSecretValue(eq(request));
+    }
+
+    @Test
+    public final void verifyTracingHandlerHandlesCustomRequest() {
+        // given
+        final AWSXRayRecorder recorder = mock(AWSXRayRecorder.class);
+        final TracingHandler handler = new TracingHandler(recorder);
+        final AmazonWebServiceRequest originalRequest = new EphemeralPutSecretValueRequest();
+        final Request<PutSecretValueRequest> request = new DefaultRequest<>(originalRequest, "Secrets Manager");
+
+        // when
+        handler.beforeRequest(request);
+
+        // then (no exceptions)
     }
 
 }

--- a/fernet-java8/src/main/java/com/macasaet/fernet/Key.java
+++ b/fernet-java8/src/main/java/com/macasaet/fernet/Key.java
@@ -245,6 +245,14 @@ public class Key {
                 && MessageDigest.isEqual(getEncryptionKey(), other.getEncryptionKey());
     }
 
+    protected void finalize() throws Throwable {
+        // zero out the secrets before making the memory available to other applications
+        for (int i = signingKey.length; --i >= 0; signingKey[i] = 0);
+        for (int i = encryptionKey.length; --i >= 0; encryptionKey[i] = 0);
+
+        super.finalize();
+    }
+
     @SuppressWarnings("PMD.LawOfDemeter")
     protected byte[] sign(final byte version, final Instant timestamp, final IvParameterSpec initializationVector,
             final byte[] cipherText, final ByteArrayOutputStream byteStream)

--- a/fernet-java8/src/main/java/com/macasaet/fernet/StringValidator.java
+++ b/fernet-java8/src/main/java/com/macasaet/fernet/StringValidator.java
@@ -35,7 +35,11 @@ public interface StringValidator extends Validator<String> {
     }
 
     default Function<byte[], String> getTransformer() {
-        return bytes -> new String(bytes, getCharset());
+        return bytes -> {
+            final String retval = new String(bytes, getCharset());
+            for (int i = bytes.length; --i >= 0; bytes[i] = 0);
+            return retval;
+        };
     }
 
 }

--- a/fernet-java8/src/main/java/com/macasaet/fernet/Validator.java
+++ b/fernet-java8/src/main/java/com/macasaet/fernet/Validator.java
@@ -98,12 +98,13 @@ public interface Validator<T> {
      * @return the deserialised contents of the token
      * @throws TokenValidationException if the token is invalid.
      */
-    @SuppressWarnings("PMD.LawOfDemeter")
+    @SuppressWarnings({"PMD.LawOfDemeter", "PMD.DataflowAnomalyAnalysis"})
     default T validateAndDecrypt(final Key key, final Token token) {
         final Instant now = Instant.now(getClock());
         final byte[] plainText = token.validateAndDecrypt(key, now.minus(getTimeToLive()), now.plus(getMaxClockSkew()));
         final T object = getTransformer().apply(plainText);
         if (!getObjectValidator().test(object)) {
+            for (int i = plainText.length; --i >= 0; plainText[i] = 0);
             throw new PayloadValidationException("Invalid Fernet token payload.");
         }
         return object;

--- a/fernet-java8/src/test/java/com/macasaet/fernet/KeyTest.java
+++ b/fernet-java8/src/test/java/com/macasaet/fernet/KeyTest.java
@@ -18,6 +18,7 @@ package com.macasaet.fernet;
 import static com.macasaet.fernet.Constants.encoder;
 import static com.macasaet.fernet.Constants.encryptionKeyBytes;
 import static com.macasaet.fernet.Constants.signingKeyBytes;
+import static nl.jqno.equalsverifier.Warning.ALL_FIELDS_SHOULD_BE_USED;
 import static nl.jqno.equalsverifier.Warning.STRICT_INHERITANCE;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -181,7 +182,7 @@ public class KeyTest {
     @Test
     public final void verifyEqualityContract() {
         // given
-        final EqualsVerifierApi<Key> verifier = EqualsVerifier.forClass(Key.class).suppress(STRICT_INHERITANCE);
+        final EqualsVerifierApi<Key> verifier = EqualsVerifier.forClass(Key.class).suppress(STRICT_INHERITANCE).suppress(ALL_FIELDS_SHOULD_BE_USED);
 
         // when / then
         verifier.verify();

--- a/src/main/config/pmd-ruleset.xml
+++ b/src/main/config/pmd-ruleset.xml
@@ -25,7 +25,14 @@ under the License.
   <description>
     These are the custom PMD rules for the Fernet Java library.
   </description>
-  <rule ref="category/pom/errorprone.xml" />
+  <rule ref="category/java/errorprone.xml">
+    <exclude name="LoggerIsNotStaticFinal" />
+  </rule>
+  <rule ref="category/java/errorprone.xml/AssignmentInOperand">
+    <properties>
+      <property name="allowFor" value="true" />
+    </properties>
+  </rule>
   <rule ref="category/java/security.xml" />
   <rule ref="category/java/bestpractices.xml">
     <exclude name="MissingOverride" />
@@ -44,12 +51,14 @@ under the License.
     <exclude name="FieldNamingConventions" />
     <exclude name="AtLeastOneConstructor" />
   </rule>
+  <rule ref="category/java/codestyle.xml/ControlStatementBraces">
+    <properties>
+      <property name="allowEmptyLoop" value="true" />
+    </properties>
+  </rule>
   <rule ref="category/java/design.xml">
     <exclude name="ExcessiveImports" />
     <exclude name="DataClass" />
-  </rule>
-  <rule ref="category/java/errorprone.xml">
-    <exclude name="LoggerIsNotStaticFinal" />
   </rule>
   <rule ref="category/java/multithreading.xml" />
   <rule ref="category/java/performance.xml" />


### PR DESCRIPTION
This change makes a best effort to clean secret data from memory before
it is made available to another process. There is absolutely no
guarantee that this effort will be successful. In addition, client code
is responsible for securing any secret data it provides to the library
or retrieves from the library.

This change is not a substitute for securing the environment in which
the library is used. Rather it attempts to decrease the surface area for
attacks.

References:
* https://github.com/veorq/cryptocoding#clean-memory-of-secret-data .
* https://www.oracle.com/technetwork/java/seccodeguide-139067.html#2-3