### PR TITLE
Discourage decryption without authentication

### DIFF
--- a/fernet-java8/src/main/java/com/macasaet/fernet/Key.java
+++ b/fernet-java8/src/main/java/com/macasaet/fernet/Key.java
@@ -171,15 +171,22 @@ public class Key {
     }
 
     /**
-     * Decrypt the payload of a Fernet token.
+     * <p>Decrypt the payload of a Fernet token.</p>
      *
-     * @param cipherText the padded encrypted payload of a token. The length <em>must</em> be a multiple of 16 (128 bits).
-     * @param initializationVector the random bytes used in the AES encryption of the token
+     * <p>Warning: Do not call this unless the cipher text has first been verified. Attempting to decrypt a cipher text
+     * that has been tampered with will leak whether or not the padding is correct and this can be used to decrypt
+     * stolen cipher text.</p>
+     *
+     * @param cipherText
+     *            the verified padded encrypted payload of a token. The length <em>must</em> be a multiple of 16 (128
+     *            bits).
+     * @param initializationVector
+     *            the random bytes used in the AES encryption of the token
      * @return the decrypted payload
      * @see Key#encrypt(byte[], IvParameterSpec)
      */
     @SuppressWarnings("PMD.LawOfDemeter")
-    public byte[] decrypt(final byte[] cipherText, final IvParameterSpec initializationVector) {
+    protected byte[] decrypt(final byte[] cipherText, final IvParameterSpec initializationVector) {
         try {
             final Cipher cipher = Cipher.getInstance(getCipherTransformation());
             cipher.init(DECRYPT_MODE, getEncryptionKeySpec(), initializationVector);


### PR DESCRIPTION
This reduces the visibility of the decryption method to discourage
client code from decrypting cipher text without having first
authenticated it. The only way to decrypt is through a "validate and
decrypt" operation.