### PR TITLE
Increase visibility of construction methods

### DIFF
--- a/fernet-java8/src/main/java/com/macasaet/fernet/Key.java
+++ b/fernet-java8/src/main/java/com/macasaet/fernet/Key.java
@@ -83,11 +83,14 @@ public class Key {
     }
 
     /**
-     * @param concatenatedKeys
-     *            an array of 32 bytes of which the first 16 is the signing key and the last 16 is the
-     *            encryption/decryption key
+     * Create a Key from a payload containing the signing and encryption
+     * key.
+     *
+     * @param concatenatedKeys an array of 32 bytes of which the first 16 is
+     *                         the signing key and the last 16 is the
+     *                         encryption/decryption key
      */
-    protected Key(final byte[] concatenatedKeys) {
+    public Key(final byte[] concatenatedKeys) {
         this(copyOfRange(concatenatedKeys, 0, signingKeyBytes),
                 copyOfRange(concatenatedKeys, signingKeyBytes, fernetKeyBytes));
     }

--- a/fernet-java8/src/main/java/com/macasaet/fernet/Token.java
+++ b/fernet-java8/src/main/java/com/macasaet/fernet/Token.java
@@ -105,8 +105,18 @@ public class Token {
         this.hmac = hmac;
     }
 
+    /**
+     * Read a Token from bytes. This does NOT validate that the token was
+     * generated using a valid {@link Key}.
+     *
+     * @param bytes a Fernet token in the form Version | Timestamp | IV |
+     *              Ciphertext | HMAC
+     * @return a new Token
+     * @throws IllegalTokenException if the input string cannot be a valid
+     *                               token irrespective of key or timestamp.
+     */
     @SuppressWarnings({"PMD.PrematureDeclaration", "PMD.DataflowAnomalyAnalysis"})
-    protected static Token fromBytes(final byte[] bytes) {
+    public static Token fromBytes(final byte[] bytes) {
         if (bytes.length < minimumTokenBytes) {
             throw new IllegalTokenException("Not enough bits to generate a Token");
         }


### PR DESCRIPTION
This increases the visibility of core construction methods that take
byte array parameters.

Fixes: #190