### PR TITLE
Run integration tests explicitly

### DIFF
--- a/fernet-aws-secrets-manager-rotator/pom.xml
+++ b/fernet-aws-secrets-manager-rotator/pom.xml
@@ -184,6 +184,10 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.2.3</version>
         <configuration>

--- a/fernet-java8/pom.xml
+++ b/fernet-java8/pom.xml
@@ -100,14 +100,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
-          <executions>
-            <execution>
-              <goals>
-                <goal>integration-test</goal>
-                <goal>verify</goal>
-              </goals>
-            </execution>
-          </executions>
       </plugin>
       <plugin>
         <groupId>org.pitest</groupId>

--- a/fernet-jersey-auth/pom.xml
+++ b/fernet-jersey-auth/pom.xml
@@ -134,6 +134,10 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
   <reporting>

--- a/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/secretinjection/SecretInjectionIT.java
+++ b/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/secretinjection/SecretInjectionIT.java
@@ -15,6 +15,7 @@
  */
 package com.macasaet.fernet.jersey.example.secretinjection;
 
+import static org.glassfish.jersey.test.TestProperties.CONTAINER_PORT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
@@ -63,6 +64,8 @@ public class SecretInjectionIT extends JerseyTest {
     protected Application configure() {
         SLF4JBridgeHandler.removeHandlersForRootLogger();
         SLF4JBridgeHandler.install();
+
+        forceSet(CONTAINER_PORT, "0");
 
         return new ExampleSecretInjectionApplication<User>();
     }

--- a/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/tokeninjection/TokenInjectionIT.java
+++ b/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/tokeninjection/TokenInjectionIT.java
@@ -15,6 +15,7 @@
  */
 package com.macasaet.fernet.jersey.example.tokeninjection;
 
+import static org.glassfish.jersey.test.TestProperties.CONTAINER_PORT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -39,6 +40,7 @@ public class TokenInjectionIT extends JerseyTest {
     protected Application configure() {
         SLF4JBridgeHandler.removeHandlersForRootLogger();
         SLF4JBridgeHandler.install();
+        forceSet(CONTAINER_PORT, "0");
         return new ExampleTokenInjectionApplication();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.2</version>
+          <version>3.0.0-M5</version>
           <configuration>
             <parallel>all</parallel>
             <useUnlimitedThreads>true</useUnlimitedThreads>
@@ -146,11 +146,25 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-failsafe-plugin</artifactId>
-          <version>2.22.2</version>
+          <version>3.0.0-M5</version>
           <configuration>
             <parallel>all</parallel>
             <useUnlimitedThreads>true</useUnlimitedThreads>
           </configuration>
+          <executions>
+            <execution>
+              <id>integration-test</id>
+              <goals>
+                <goal>integration-test</goal>
+              </goals>
+            </execution>
+            <execution>
+              <id>verify</id>
+              <goals>
+                <goal>verify</goal>
+              </goals>
+            </execution>
+          </executions>
         </plugin>
         <plugin>
           <groupId>org.pitest</groupId>


### PR DESCRIPTION
This adds the integration tests directly to the project lifecycle rather
than only running them as part of mutation testing. This should have no
material impact other than to demonstrate that the integration tests ran
in the build output rather than relying on the mutation testing report.