### PR TITLE
Force newest version of commons-codec

### DIFF
--- a/fernet-aws-secrets-manager-rotator/pom.xml
+++ b/fernet-aws-secrets-manager-rotator/pom.xml
@@ -69,6 +69,16 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <version>4.5.12</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <version>1.15</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>


### PR DESCRIPTION
Force the newest version of commons-codec and httpclient, which is the
only dependency that uses commons-codec at this time. This avoids this
potential vulnerability:
https://app.snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518 .