### PR TITLE
Remove Sonar integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ jobs:
     - language: java
       jdk: openjdk11
       script:
-        - ./mvnw org.jacoco:jacoco-maven-plugin:prepare-agent clean install sonar:sonar site
+        - ./mvnw clean install site
 env:
   jobs:
     secure: AVFhPadriChDFAi6WzcifaEmjXaIdNCMmmsCr2CJw63SptFZ9HcC670oJWTGxVvWCGjTOQAXkwcD1ND4poJCfuXbaN/STPSQxAfF6KGrtMwVcssfbQU0h2XG2N/I8VNcldBFsCwGIe+tvUCnVK0bH9Clst/3sC5HokI4CPGL5YUG+c57rkhh4PDl5gsJHbBdbO7XL8ftjnBkWPuZ9s6NnzJEe12G8s4llUGyzPUpYVer+L0iREdCgAbvD1HZ7ejox2wEmDScKR58fnyF64m4MVOb5Wf0WCh3C9kZH1UrqqOl/ssG+sM6RuNf9piCizPfQWJ3tSiAaqWSO6DdHXS66MPipkeWg6fcqijz+yDgJbjqsB/0cV+oP3RFNbTHpG6oiFwMY4dX9Wnrz8wbhOiebWo2EwusUuV3JigvGrQQv0zxYkTauDDXCMEJGALDoU/QUNYtiQekx7AsNlUScNdqbL1+IZkcVQ8UdXUiZR8mTebpEFCpR5v1LShehq4G4jgp0d3x4KPnBbMjY00R5dmGOdAPRkzoCl7WHPg33VVWcFyyAJ6gn4ijPRvSofdEoffuI88MGFmtkgA/gzYEYkVAdKhmr+9URSwfhXFnNAXi3s9FLf7oi8RvwR7Bl85pOzTD5nzV6KxeVWI08pDq6PoORUc+QJjwulIdGSQNQg4nHbc=
@@ -46,14 +46,9 @@ addons:
   apt:
     packages:
       - xmlstarlet # XML manipulation tool to edit default setting.xml
-  sonarcloud:
-    organization: 'l0s-github'
-    token:
-      secure: "gD90ITnrkOS1v18AZN6PWelF3chbNwP/9leSHudGior+j62sqjs5zoY26nnExyfUYUjle3rhCsIk2om1L2/tXy24k7b3nWgG7yCt229VaYoMmcT7xcAtf/3jPGYZ/lXP/Jlsb1UXZq3PutbXOIl0+RqRX8opXbUDEVycH+5pCJ/sIoteftmdMBNZCoMdc7g1D3GYFb1dwltcrYhVW4zLCNtQOK6LyAHnDpHEdT5VGjjGM7EEbMNJRJS8NJWpO24LFKrcGlX3lDJksZsykYFmI1M0Ib7TkeuqhLunqbLYY0kJb4cNXQC+p0bT3aC3kiCVCT18Up83qi6zzudkMTPnpnnUyvScx5TpmhK6Hjmb0eWviasZH3bv5AOtsZuEkh/je0TLXcheAHw0sfHnNBtG6oAEKzDQlMzLeSLDJcIbmW0iLyjWFm+anwWiaTdYjLGEzimpuMdeP8PxSYgBbroqN37/jeVBwAJrRNPqWAaqf66fsWBuRkWaxX3Pag1evN9FaWis7y6aj4DqDu/nszIzOkEgTDlxPrCytVThEErs47b2HWPhmWY9V/cItkHwO/yNTiRHJb6wJocShfGTzHkVV0ZuMvqJD1UcwXPZdywKcpnlrr98osH+Td2XtCC4sQCQJTf/qwAKsGsF0AI8q3TsUG6LJMTHwUFvJXax3DS+Yus="
 cache:
   directories:
     - $HOME/.m2
-    - $HOME/.sonar/cache
     - fernet-java8/target/pmd
     - fernet-aws-secrets-manager-rotator/target/pmd
     - fernet-jersey-auth/target/pmd

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build Status](https://travis-ci.com/l0s/fernet-java8.svg?branch=master)](https://travis-ci.com/l0s/fernet-java8)
 [![Javadocs](https://javadoc.io/badge/com.macasaet.fernet/fernet-java8.svg)](https://javadoc.io/doc/com.macasaet.fernet/fernet-java8)
 [![Known Vulnerabilities](https://snyk.io/test/github/l0s/fernet-java8/badge.svg?targetFile=pom.xml)](https://snyk.io/test/github/l0s/fernet-java8?targetFile=pom.xml)
-[![Sonar](https://sonarcloud.io/api/project_badges/measure?project=com.macasaet.fernet%3Afernet-java&metric=alert_status)](https://sonarcloud.io/dashboard?id=com.macasaet.fernet%3Afernet-java)
 
 This is an implementation of the
 [Fernet Spec](https://github.com/fernet/spec) using Java 8.

--- a/fernet-aws-secrets-manager-rotator/README.md
+++ b/fernet-aws-secrets-manager-rotator/README.md
@@ -106,8 +106,6 @@ to instantiate each key.
 
 [PIT Mutation Testing  Report](https://l0s.github.io/fernet-java8/fernet-aws-secrets-manager-rotator/pit-reports/index.html)
 
-[SonarCloud Code Quality](https://sonarcloud.io/dashboard?id=com.macasaet.fernet%3Afernet-aws-secrets-manager-rotator)
-
 ## References
 
 [AWS Secrets Manager Documentation](https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html)

--- a/fernet-java8/README.md
+++ b/fernet-java8/README.md
@@ -4,10 +4,7 @@ See the parent module for [documentation](https://github.com/l0s/fernet-java8).
 
 ## Development
 
-[PIT Mutation Testing  Report](https://l0s.github.io/fernet-java8/fernet-java8/pit-reports/index.html)
-
-[SonarCloud Code Quality](https://sonarcloud.io/dashboard?id=com.macasaet.fernet%3Afernet-java8)
-
+[PIT Mutation Testing Report](https://l0s.github.io/fernet-java8/fernet-java8/pit-reports/index.html)
 
 ## License
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,6 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <pmd.version>6.20.0</pmd.version>
     <jackson.version>2.11.2</jackson.version>
-    <sonar.organization>l0s-github</sonar.organization>
-    <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <dependency.locations.enabled>false</dependency.locations.enabled>
   </properties>
   <scm>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,0 @@
-sonar.projectKey=fernet-java
-sonar.sources=.


### PR DESCRIPTION
Sonar seems to have removed the ability to customise the rules it
applies. I plan to invest more static analysis that occurs within the
build (e.g. PMD) rather than externally.