### PR TITLE
Use better password auth example

### DIFF
--- a/fernet-jersey-auth/pom.xml
+++ b/fernet-jersey-auth/pom.xml
@@ -99,6 +99,12 @@
       <artifactId>jaxb-api</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.bouncycastle</groupId>
+      <artifactId>bcpkix-jdk15on</artifactId>
+      <version>1.70</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <distributionManagement>
     <site>

--- a/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/FernetSecretValueParamProviderTest.java
+++ b/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/FernetSecretValueParamProviderTest.java
@@ -67,7 +67,7 @@ public class FernetSecretValueParamProviderTest {
     private Function<ContainerRequest, String> function;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         mockContext = openMocks(this); // there seems to be a bug with @RunWith(MockitoJUnitRunner.class)
         given(parameter.isAnnotationPresent(FernetSecret.class)).willReturn(true);
         function = provider.getValueProvider(parameter);

--- a/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/FernetTokenValueParamProviderTest.java
+++ b/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/FernetTokenValueParamProviderTest.java
@@ -34,7 +34,6 @@ import org.junit.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
-import com.macasaet.fernet.Key;
 import com.macasaet.fernet.Token;
 import com.macasaet.fernet.jaxrs.FernetToken;
 
@@ -50,14 +49,12 @@ public class FernetTokenValueParamProviderTest {
     @Mock
     private Parameter parameter;
     @Mock
-    private Key key;
-    @Mock
     private Token token;
 
     private Function<ContainerRequest, Token> function;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         mockContext = openMocks(this); // there seems to be a bug with @RunWith(MockitoJUnitRunner.class)
         doReturn(Token.class).when(parameter).getRawType();
         given(parameter.isAnnotationPresent(FernetToken.class)).willReturn(true);

--- a/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/TokenHeaderUtilityTest.java
+++ b/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/TokenHeaderUtilityTest.java
@@ -39,7 +39,7 @@ public class TokenHeaderUtilityTest {
     private SecureRandom random;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         utility = new TokenHeaderUtility();
         random = new SecureRandom();
     }

--- a/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/common/AuthenticationResource.java
+++ b/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/common/AuthenticationResource.java
@@ -38,8 +38,8 @@ import com.macasaet.fernet.Validator;
  * This is an example of a resource that generates a Fernet token. Here, the
  * Fernet token identifies a session. Once a client has started a session using
  * this resource, they can issue requests by providing only the token they have
- * been provided. The do not need to provide login credentials again until the
- * token expires.
+ * been provided. They do not need to provide login credentials again until the
+ * session expires or is revoked.
  *
  * <p>Copyright &copy; 2017 Carlos Macasaet.</p>
  *
@@ -51,7 +51,7 @@ public class AuthenticationResource {
 	private final SecureRandom random = new SecureRandom();
 
 	@Inject
-	private UserRepository repository;
+	private PasswordService passwordService;
 	@Inject
 	private SessionRepository sessionRepository;
 	@Inject
@@ -81,8 +81,8 @@ public class AuthenticationResource {
 	@Produces(MediaType.TEXT_PLAIN)
 	@Consumes(MediaType.APPLICATION_JSON)
 	public String createSession(final LoginRequest request) {
-		final User user = repository.findUser(request.getUsername());
-		if (user != null && user.isPasswordCorrect(request.getSingleRoundPasswordHash())) {
+		final User user = passwordService.authenticateUser(request.getUsername(), request.getPlainTextPassword());
+		if (user != null) {
 			// password is correct, so generate an ephemeral session
 		    // store the session ID in the token payload
 		    final Session session = new Session(request.getUsername());

--- a/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/common/LoginRequest.java
+++ b/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/common/LoginRequest.java
@@ -27,15 +27,15 @@ package com.macasaet.fernet.jersey.example.common;
 public class LoginRequest {
 
 	private String username;
-	private String singleRoundPasswordHash;
+	private CharSequence plainTextPassword;
 
 	public LoginRequest() {
 	}
 
-	public LoginRequest(String username, String singleRoundPasswordHash) {
+	public LoginRequest(final String username, final CharSequence plainTextPassword) {
 	    this();
 		setUsername(username);
-		setSingleRoundPasswordHash(singleRoundPasswordHash);
+		setPlainTextPassword(plainTextPassword);
 	}
 
 	public String getUsername() {
@@ -46,15 +46,14 @@ public class LoginRequest {
 		this.username = username;
 	}
 
-	/**
-	 * @return the SHA-256 hash of the plain-text password
-	 */
-	public String getSingleRoundPasswordHash() {
-		return singleRoundPasswordHash;
+	public CharSequence getPlainTextPassword() {
+		return plainTextPassword;
 	}
 
-	protected void setSingleRoundPasswordHash(String singleRoundPasswordHash) {
-		this.singleRoundPasswordHash = singleRoundPasswordHash;
+	protected void setPlainTextPassword(final CharSequence plainTextPassword) {
+		if(plainTextPassword == null || plainTextPassword.length() == 0) {
+			throw new IllegalArgumentException("plainTextPassword must be specified");
+		}
+		this.plainTextPassword = plainTextPassword;
 	}
-
 }

--- a/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/common/PasswordService.java
+++ b/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/common/PasswordService.java
@@ -1,0 +1,271 @@
+/**
+ Copyright 2017-2021 Carlos Macasaet
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+package com.macasaet.fernet.jersey.example.common;
+
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.*;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import net.bytebuddy.utility.RandomString;
+import org.bouncycastle.crypto.generators.Argon2BytesGenerator;
+import org.bouncycastle.crypto.params.Argon2Parameters;
+
+/**
+ * A service for checking and setting user passwords.
+ *
+ * <p>Copyright &copy; 2017-2022 Carlos Macasaet.</p>
+ *
+ * @author Carlos Macasaet
+ */
+@Singleton
+public class PasswordService {
+
+    private static final Charset charset = StandardCharsets.UTF_8;
+    private static final SecureRandom random = new SecureRandom();
+    private static final Base64.Encoder encoder = Base64.getEncoder();
+
+    private final User fakeUser;
+
+    @Inject
+    private UserRepository repository;
+
+    {
+        fakeUser = new User("placeholder", false, "");
+        fakeUser.setPasswordHash(RandomString.make(32));
+    }
+
+    /**
+     * Find the user and verify that the correct password was provided. This method should take the same amount of time
+     * regardless of whether a valid username or the correct password are provided.
+     *
+     * @param username the unique User identifier
+     * @param password the plain text password
+     * @return the corresponding User if the username is valid and the password is correct or else null
+     */
+    public User authenticateUser(final String username, final CharSequence password) {
+        final User user = repository.findUser(username);
+        if(user != null) {
+            if(isPasswordCorrect(user, password)) {
+                return user;
+            }
+        } else {
+            // ensure the same amount of time is taken in case the username is not valid
+            isPasswordCorrect(fakeUser, password);
+        }
+        return null;
+    }
+
+    /**
+     * Convert a plain text password into a hash in PHC format
+     *
+     * @param newPassword the user's new desired password in plain text
+     * @return the password hash, salt, and parameters in PHC format
+     */
+    public CharSequence hashPassword(final CharSequence newPassword) {
+        final byte[] salt = new byte[16];
+        random.nextBytes(salt);
+        final int iterations = 48;
+        final int memoryAsKb = 4096;
+        final int parallelism = 8;
+        final Argon2Parameters parameters = new Argon2Parameters.Builder(Argon2Parameters.ARGON2_id)
+                .withIterations(iterations)
+                .withMemoryAsKB(memoryAsKb)
+                .withParallelism(parallelism)
+                .withSalt(salt)
+                .build();
+        final Argon2BytesGenerator generator = new Argon2BytesGenerator();
+        generator.init(parameters);
+        final char[] plainTextPassword = new char[newPassword.length()];
+        for(int i = newPassword.length(); --i >= 0; plainTextPassword[i] = newPassword.charAt(i));
+        final byte[] hash = new byte[32];
+        generator.generateBytes(plainTextPassword, hash);
+        final String memoryString = Integer.toString(memoryAsKb);
+        final String iterationsString = Integer.toString(iterations);
+        final String parallelismString = Integer.toString(parallelism);
+        final ByteBuffer encodedSaltBytes = ByteBuffer.wrap(encoder.encode(salt));
+        final CharBuffer encodedSaltChars = stripPadding(charset.decode(encodedSaltBytes));
+        final ByteBuffer encodedHashBytes = ByteBuffer.wrap(encoder.encode(hash));
+        final CharBuffer encodedHashChars = stripPadding(charset.decode(encodedHashBytes));
+
+        final CharBuffer result = CharBuffer.allocate(1 + 8 + 5 + 3
+                + memoryString.length() + 3 + iterationsString.length() + 3 + parallelismString.length()
+                + 1 + encodedSaltChars.length() + 1 + encodedHashChars.length());
+        result.append('$');
+        result.append("argon2id");
+        result.append("$v=19");
+        result.append("$m=").append(memoryString);
+        result.append("$t=").append(iterationsString);
+        result.append("$p=").append(parallelismString);
+        result.append('$').append(encodedSaltChars);
+        result.append('$').append(encodedHashChars);
+        result.limit(result.position());
+        result.position(0);
+
+        random.nextBytes(encodedHashBytes.array());
+        random.nextBytes(hash);
+        random.nextBytes(encodedSaltBytes.array());
+        random.nextBytes(salt);
+        encodedHashChars.position(0);
+        encodedHashChars.put(RandomString.make(encodedHashChars.length()));
+        encodedSaltChars.position(0);
+        encodedSaltChars.put(RandomString.make(encodedSaltChars.length()));
+
+        return result;
+    }
+
+    /**
+     * @param plainTextPassword the password as provided by the client
+     * @return true if and only if the password is correct
+     */
+    public boolean isPasswordCorrect(final User user, final CharSequence plainTextPassword) {
+        final CharSequence phc = user.getPasswordHash();
+        final CharSequence[] hashComponents = split(phc);
+        int componentIndex = 0;
+        if (hashComponents[componentIndex].length() != 0) {
+            throw new IllegalStateException("Invalid password PHC component at index: " + componentIndex);
+        }
+        componentIndex++;
+        final int algorithmId = getAlgorithmId(hashComponents[componentIndex]);
+        Argon2Parameters.Builder builder = new Argon2Parameters.Builder(algorithmId);
+        componentIndex++;
+        final Map<String, String> workParameters = new HashMap<>();
+        boolean processedSalt = false;
+        final Collection<? extends String> requiredParameters = Arrays.asList("m", "t", "p");
+        byte[] hash = null;
+        while (componentIndex < hashComponents.length) {
+            final CharSequence component = hashComponents[componentIndex];
+            final int equalsIndex = indexOfAssignmentOperator(component);
+            if (equalsIndex < 0) {
+                // not a work parameter
+                if (!processedSalt) {
+                    final CharBuffer charBuffer = CharBuffer.wrap(component);
+                    final ByteBuffer byteBuffer = charset.encode(charBuffer);
+                    final ByteBuffer saltBuffer = Base64.getDecoder().decode(byteBuffer);
+                    builder = builder.withSalt(saltBuffer.array());
+                    processedSalt = true;
+                } else {
+                    final CharBuffer charBuffer = CharBuffer.wrap(component);
+                    final ByteBuffer byteBuffer = charset.encode(charBuffer);
+                    final ByteBuffer hashBuffer = Base64.getDecoder().decode(byteBuffer);
+                    hash = hashBuffer.array();
+                }
+            } else {
+                // work parameter
+                final String key = component.subSequence(0, equalsIndex).toString();
+                final String value = component.subSequence(equalsIndex + 1, component.length()).toString();
+                workParameters.put(key, value);
+            }
+            componentIndex++;
+
+            if (workParameters.keySet().containsAll(requiredParameters)
+                    && processedSalt && hash != null) {
+                break;
+            }
+        }
+        if (!workParameters.containsKey("m")) {
+            throw new IllegalStateException("PHC is missing memory parameter");
+        }
+        builder = builder.withMemoryAsKB(Integer.parseInt(workParameters.get("m")));
+        if (!workParameters.containsKey("t")) {
+            throw new IllegalArgumentException("PHC is missing iterations parameter");
+        }
+        builder = builder.withIterations(Integer.parseInt(workParameters.get("t")));
+        if (!workParameters.containsKey("p")) {
+            throw new IllegalArgumentException("PHC is missing parallelism parameter");
+        }
+        builder = builder.withParallelism(Integer.parseInt(workParameters.get("p")));
+        final Argon2Parameters parameters = builder.build();
+        final Argon2BytesGenerator generator = new Argon2BytesGenerator();
+        generator.init(parameters);
+
+        if (hash == null) {
+            throw new IllegalStateException("PHC is missing the password hash");
+        }
+
+        final byte[] actualBytes = new byte[hash.length];
+        final List<Character> plainChars = plainTextPassword.chars().mapToObj(i -> (char)i).collect(Collectors.toList());
+        final char[] plainCharArray = new char[plainChars.size()];
+        for(int i = plainChars.size(); --i >= 0; plainCharArray[i] = plainChars.get(i));
+        generator.generateBytes(plainCharArray, actualBytes);
+        return MessageDigest.isEqual(actualBytes, hash);
+    }
+
+    protected int getAlgorithmId(CharSequence hashComponents) {
+        final String id = hashComponents.toString();
+        final int algorithmId = "argon2i".equalsIgnoreCase(id)
+                ? Argon2Parameters.ARGON2_i
+                : "argon2d".equalsIgnoreCase(id)
+                ? Argon2Parameters.ARGON2_d
+                : "argon2id".equalsIgnoreCase(id)
+                ? Argon2Parameters.ARGON2_id
+                : Integer.MIN_VALUE;
+        if (algorithmId < 0) {
+            throw new IllegalStateException("Unsupported algorithm: " + algorithmId);
+        }
+        return algorithmId;
+    }
+
+    protected int indexOfAssignmentOperator(final CharSequence sequence) {
+        for (int i = sequence.length(); --i >= 0; ) {
+            if (sequence.charAt(i) == '=') {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    protected CharSequence[] split(final CharSequence string) {
+        final ArrayList<CharSequence> components = new ArrayList<>();
+        int start = 0;
+        int lastEnd = -1;
+        for (int i = 0; i < string.length(); i++) {
+
+            if (string.charAt(i) == '$') {
+                if (i - start >= 0) {
+                    components.add(string.subSequence(start, i));
+                }
+                start = i + 1;
+                lastEnd = start;
+            }
+        }
+        if(lastEnd > 0 && lastEnd < string.length()) {
+            components.add(string.subSequence(lastEnd, string.length()));
+        }
+        return components.toArray(new CharSequence[0]);
+    }
+
+    protected CharBuffer stripPadding(final CharBuffer buffer) {
+        CharBuffer result = CharBuffer.allocate(buffer.capacity());
+        while(buffer.hasRemaining()) {
+            final char c = buffer.get();
+            if(c == '=') {
+                break;
+            }
+            result = result.put(c);
+        }
+
+        result.limit(result.position());
+        result.position(0);
+        return result;
+    }
+}

--- a/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/common/User.java
+++ b/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/common/User.java
@@ -15,13 +15,6 @@
  */
 package com.macasaet.fernet.jersey.example.common;
 
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.SecureRandom;
-import java.util.Base64;
-import java.util.Base64.Decoder;
-import java.util.Base64.Encoder;
-
 /**
  * This is an example of a POJO that may be used for both authentication and authorisation.
  *
@@ -31,92 +24,38 @@ import java.util.Base64.Encoder;
  */
 public class User {
 
-	private static final SecureRandom random = new SecureRandom();
-	private static final Encoder encoder = Base64.getUrlEncoder();
-	private static final Decoder decoder = Base64.getUrlDecoder();
+    private CharSequence passwordHash;
+    private boolean trustworthy;
+    private String secret = "42";
 
-	private String salt;
-	private String twoRoundPasswordHash;
-	private boolean trustworthy;
-	private String secret = "42";
-
-	public User() {
-	}
-
-	public User(final String singleRoundPasswordHash, final boolean trustworthy) {
-		setPassword(singleRoundPasswordHash);
-		setTrustworthy(trustworthy);
-	}
-
-	/**
-	 * @return salt used to generate the two-round password hash
-	 * @see #getTwoRoundPasswordHash()
-	 */
-	public String getSalt() {
-		return salt;
-	}
-
-	protected void setSalt(String salt) {
-		this.salt = salt;
-	}
-
-	/**
-	 * @return the password as it is stored in the datastore. It is a function
-	 *         of the single-round password hash and the salt
-	 * @see #getSalt()
-	 */
-	public String getTwoRoundPasswordHash() {
-		return twoRoundPasswordHash;
-	}
-
-	protected void setTwoRoundPasswordHash(final String passwordHash) {
-		this.twoRoundPasswordHash = passwordHash;
-	}
-
-	/**
-	 * A contrived field used for demonstrating domain-specific token validation.
-	 */
-	public boolean isTrustworthy() {
-		return trustworthy;
-	}
-
-	public void setTrustworthy(boolean trustworthy) {
-		this.trustworthy = trustworthy;
-	}
-
-	/**
-	 * @param singleRoundPasswordHash password that has been hashed once between the client and the server (Base 64 URL encoded)
-	 * @return true if and only if the password is correct
-	 */
-	public boolean isPasswordCorrect(final String singleRoundPasswordHash) {
-		try {
-			final MessageDigest digest = MessageDigest.getInstance("SHA-512");
-			digest.update(decoder.decode(singleRoundPasswordHash));
-			digest.update(decoder.decode(getSalt()));
-			return MessageDigest.isEqual(digest.digest(), decoder.decode(getTwoRoundPasswordHash()));
-		} catch (final NoSuchAlgorithmException e) {
-			throw new RuntimeException("Password hashing algorithm not found: " + e.getMessage(), e);
-		}
-	}
-
-	/**
-	 * Set the salt and password based on a new single-round password hash.
-	 *
-	 * @param singleRoundPasswordHash SHA-256 hash of the plain-text password
-	 */
-	public void setPassword(final String singleRoundPasswordHash) {
-		final byte[] bytes = new byte[16];
-		random.nextBytes(bytes);
-		setSalt(encoder.encodeToString(bytes));
-		try {
-			final MessageDigest digest = MessageDigest.getInstance("SHA-512");
-			digest.update(decoder.decode(singleRoundPasswordHash));
-			digest.update(decoder.decode(getSalt()));
-			setTwoRoundPasswordHash(encoder.encodeToString(digest.digest()));
-		} catch (final NoSuchAlgorithmException e) {
-			throw new RuntimeException("Password hashing algorithm not found: " + e.getMessage(), e);
-		}
+    public User(final CharSequence passwordHash, final boolean trustworthy, final String secret) {
+        setPasswordHash(passwordHash);
+        setTrustworthy(trustworthy);
+        setSecret(secret);
     }
+
+    public CharSequence getPasswordHash() {
+        return this.passwordHash;
+    }
+
+    protected void setPasswordHash(final CharSequence passwordHash) {
+        if (passwordHash == null || passwordHash.length() == 0) {
+            throw new IllegalArgumentException("passwordHash must be specified");
+        }
+        this.passwordHash = passwordHash;
+    }
+
+    /**
+     * A contrived field used for demonstrating domain-specific token validation.
+     */
+    public boolean isTrustworthy() {
+        return trustworthy;
+    }
+
+    public void setTrustworthy(boolean trustworthy) {
+        this.trustworthy = trustworthy;
+    }
+
 
     /**
      * @return a value that should only be presented to authenticated principals

--- a/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/common/UserRepository.java
+++ b/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/common/UserRepository.java
@@ -17,6 +17,7 @@ package com.macasaet.fernet.jersey.example.common;
 
 import static java.util.Collections.unmodifiableMap;
 
+import java.nio.CharBuffer;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,13 +33,13 @@ import javax.inject.Singleton;
 @Singleton
 public class UserRepository {
 
-    private Map<String, User> datastore;
+    private final Map<String, User> datastore;
 
     {
         final Map<String, User> map = new HashMap<>();
-        map.put("alice", new User("1QYCGznPQ1z8T1aX_CNXKheDMAnNSfq_xnSxWXPLeKU=", true));
-        map.put("bob", new User("98UXS8DlhmSuc6-PtTnFNV7cJGluRn1z4By-W_IMs4Q=", true));
-        map.put("mallory", new User("Lpei3NWxhPsyc5NrJp6zkbHj4P_bji6Z7GsY0JSAUb8=", false));
+        map.put("alice", new User(CharBuffer.wrap("$argon2id$v=19$m=4096$t=48$p=8$6X6h6b9CeF1hydBU5n0Mow$ZxI+2f0e5pjqL84uUdCuL4yXNmiiy/L4fIEcm+ewHo4"), true, "42"));
+        map.put("bob", new User(CharBuffer.wrap("$argon2id$v=19$m=4096$t=48$p=8$YKQOlEgfpqS+30dEAY+Oiw$DVh47bymn+qHa069VIaQBbUpFFWz19kcjf9d8gbyjMY"), true, "524287"));
+        map.put("mallory", new User(CharBuffer.wrap("$argon2id$v=19$m=4096$t=48$p=8$FVC8xnLcADH9NQ1HUrMhIQ$FuNHVh5XJmZWNW8f/NkPrtq9tySvJvEPjTI/kOOkzbo"), false, "665280"));
         datastore = unmodifiableMap(map);
     }
 

--- a/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/secretinjection/ExampleSecretInjectionApplication.java
+++ b/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/secretinjection/ExampleSecretInjectionApplication.java
@@ -22,6 +22,7 @@ import java.util.logging.Logger;
 import javax.inject.Singleton;
 import javax.ws.rs.core.GenericType;
 
+import com.macasaet.fernet.jersey.example.common.*;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.internal.inject.Binder;
 import org.glassfish.jersey.logging.LoggingFeature;
@@ -31,12 +32,6 @@ import org.glassfish.jersey.server.ResourceConfig;
 import com.macasaet.fernet.Key;
 import com.macasaet.fernet.Validator;
 import com.macasaet.fernet.jersey.FernetSecretFeature;
-import com.macasaet.fernet.jersey.example.common.AuthenticationResource;
-import com.macasaet.fernet.jersey.example.common.CustomTokenValidator;
-import com.macasaet.fernet.jersey.example.common.KeySupplier;
-import com.macasaet.fernet.jersey.example.common.Session;
-import com.macasaet.fernet.jersey.example.common.SessionRepository;
-import com.macasaet.fernet.jersey.example.common.UserRepository;
 
 /**
  * <p>This is an example Jersey application configuration that enables injection of a Fernet token payload. Your
@@ -58,6 +53,7 @@ public class ExampleSecretInjectionApplication<T> extends ResourceConfig {
         protected void configure() {
             bind(UserRepository.class).to(UserRepository.class).in(Singleton.class);
             bind(SessionRepository.class).to(SessionRepository.class).in(Singleton.class);
+            bind(PasswordService.class).to(PasswordService.class).in(Singleton.class);
             bind(CustomTokenValidator.class).to(new GenericType<Validator<T>>(){}).in(Singleton.class);
             bind(CustomTokenValidator.class).to(new GenericType<Validator<Session>>(){}).in(Singleton.class);
             bind(KeySupplier.class).to(new GenericType<Supplier<Collection<Key>>>(){}).in(Singleton.class);

--- a/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/secretinjection/ProtectedResource.java
+++ b/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/secretinjection/ProtectedResource.java
@@ -43,13 +43,12 @@ public class ProtectedResource {
     /**
      * This is a secured endpoint. The Fernet token is passed in via the X-Auth-Token header parameter.
      *
-     * @param authHeader
-     *            a Fernet token
+     * @param session the session object for an authenticated user
      * @return the secret information
      */
     @GET
     public String getSecret(@FernetSecret final Session session) {
-        // if the token is invalid, an exception will be thrown and the next
+        // if the token is invalid or the session is revoked, an exception will be thrown and the next
         // line will not be executed
         // additional authorisation rules can be evaluated here such as ensuring
         // the user specified by the token has

--- a/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/secretinjection/SecretInjectionIT.java
+++ b/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/secretinjection/SecretInjectionIT.java
@@ -20,7 +20,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
@@ -79,7 +79,7 @@ public class SecretInjectionIT extends JerseyTest {
     @Test
     public final void verifySuccessfulBusinessRuleCheck() {
         // given
-        final LoginRequest login = new LoginRequest("alice", "1QYCGznPQ1z8T1aX_CNXKheDMAnNSfq_xnSxWXPLeKU=");
+        final LoginRequest login = new LoginRequest("alice", "frog washer kirtle gaily fipple clunch");
         final Entity<LoginRequest> entity = Entity.json(login);
         final String tokenString =  target("session").request().accept(MediaType.TEXT_PLAIN_TYPE).post(entity, String.class);
 
@@ -98,7 +98,7 @@ public class SecretInjectionIT extends JerseyTest {
     @Test
     public final void verifyFailedBusinessRuleCheck() {
         // given
-        final LoginRequest login = new LoginRequest("mallory", "Lpei3NWxhPsyc5NrJp6zkbHj4P_bji6Z7GsY0JSAUb8=");
+        final LoginRequest login = new LoginRequest("mallory", "puling nach abend wield xenium holmos");
         final Entity<LoginRequest> entity = Entity.json(login);
         final String tokenString =  target("session").request().accept(MediaType.TEXT_PLAIN_TYPE).post(entity, String.class);
 
@@ -117,7 +117,7 @@ public class SecretInjectionIT extends JerseyTest {
     @Test
     public final void verifyFailedLogin() {
         // given
-        final LoginRequest login = new LoginRequest("bob", "NReIudfT_iovLMo-MCX8sClVr3UwbeEhAq7er6X_Kps=");
+        final LoginRequest login = new LoginRequest("bob", "raia lehr import foehn read albata");
         final Entity<LoginRequest> entity = Entity.json(login);
 
         // when / then
@@ -160,18 +160,19 @@ public class SecretInjectionIT extends JerseyTest {
     @Test
     public final void verifyRevokedTokenUnusable() {
         // given
-        final LoginRequest login = new LoginRequest("alice", "1QYCGznPQ1z8T1aX_CNXKheDMAnNSfq_xnSxWXPLeKU=");
+        final LoginRequest login = new LoginRequest("alice", "frog washer kirtle gaily fipple clunch");
         final Entity<LoginRequest> entity = Entity.json(login);
         final String tokenString = target("session").request().accept(MediaType.TEXT_PLAIN_TYPE).post(entity,
                 String.class);
 
-        final Response revokeResponse = target("session").path("revocation").request(MediaType.TEXT_PLAIN_TYPE)
-                .put(Entity.text(tokenString));
-        assertEquals(204, revokeResponse.getStatus());
+        try(Response revokeResponse = target("session").path("revocation").request(MediaType.TEXT_PLAIN_TYPE)
+                .put(Entity.text(tokenString))) {
+            assertEquals(204, revokeResponse.getStatus());
 
-        // when / then
-        assertThrows(ForbiddenException.class,
-                () -> target("secrets").request().header("X-Authorization", tokenString).get(String.class));
+            // when / then
+            assertThrows(ForbiddenException.class,
+                    () -> target("secrets").request().header("X-Authorization", tokenString).get(String.class));
+        }
     }
 
     /**
@@ -181,7 +182,7 @@ public class SecretInjectionIT extends JerseyTest {
     @Test
     public final void verifyRenewedTokenUsable() {
         // given
-        final LoginRequest login = new LoginRequest("alice", "1QYCGznPQ1z8T1aX_CNXKheDMAnNSfq_xnSxWXPLeKU=");
+        final LoginRequest login = new LoginRequest("alice", "frog washer kirtle gaily fipple clunch");
         final String firstToken = target("session").request().accept(MediaType.TEXT_PLAIN_TYPE).post(Entity.json(login),
                 String.class);
         final String secondToken = target("session").path("renewal").request(MediaType.TEXT_PLAIN_TYPE)
@@ -212,11 +213,11 @@ public class SecretInjectionIT extends JerseyTest {
     }
 
     @Test
-    public final void verifyInvalidTokenReturnsNotAuthorized() throws UnsupportedEncodingException {
+    public final void verifyInvalidTokenReturnsNotAuthorized() {
         // given
         final SecureRandom random = new SecureRandom();
         final Key key = Key.generateKey(random);
-        final byte[] plainText = "this is a valid token".getBytes("UTF-8");
+        final byte[] plainText = "this is a valid token".getBytes(StandardCharsets.UTF_8);
         final Token validToken = Token.generate(random, key, plainText);
         final byte[] cipherText = key.encrypt(plainText, validToken.getInitializationVector());
         final Token invalidToken = new Token(validToken.getVersion(), validToken.getTimestamp(),

--- a/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/tokeninjection/ExampleTokenInjectionApplication.java
+++ b/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/tokeninjection/ExampleTokenInjectionApplication.java
@@ -21,6 +21,7 @@ import java.util.function.Supplier;
 import javax.inject.Singleton;
 import javax.ws.rs.core.GenericType;
 
+import com.macasaet.fernet.jersey.example.common.*;
 import org.glassfish.jersey.internal.inject.AbstractBinder;
 import org.glassfish.jersey.internal.inject.Binder;
 import org.glassfish.jersey.server.ResourceConfig;
@@ -28,12 +29,6 @@ import org.glassfish.jersey.server.ResourceConfig;
 import com.macasaet.fernet.Key;
 import com.macasaet.fernet.Validator;
 import com.macasaet.fernet.jersey.FernetTokenFeature;
-import com.macasaet.fernet.jersey.example.common.AuthenticationResource;
-import com.macasaet.fernet.jersey.example.common.CustomTokenValidator;
-import com.macasaet.fernet.jersey.example.common.KeySupplier;
-import com.macasaet.fernet.jersey.example.common.Session;
-import com.macasaet.fernet.jersey.example.common.SessionRepository;
-import com.macasaet.fernet.jersey.example.common.UserRepository;
 
 /**
  * <p>This is an example Jersey application configuration that enables injection of a Fernet token.
@@ -49,6 +44,7 @@ public class ExampleTokenInjectionApplication extends ResourceConfig {
     private final Binder fernetConfigurationBinder = new AbstractBinder() {
         protected void configure() {
             bind(UserRepository.class).to(UserRepository.class).in(Singleton.class);
+            bind(PasswordService.class).to(PasswordService.class).in(Singleton.class);
             bind(SessionRepository.class).to(SessionRepository.class).in(Singleton.class);
             bind(CustomTokenValidator.class).to(new GenericType<Validator<Session>>(){}).in(Singleton.class);
             bind(KeySupplier.class).to(new GenericType<Supplier<Collection<Key>>>(){}).in(Singleton.class);

--- a/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/tokeninjection/ProtectedResource.java
+++ b/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/tokeninjection/ProtectedResource.java
@@ -71,7 +71,7 @@ public class ProtectedResource {
     /**
      * This is a secured endpoint. The Fernet token is passed in via the X-Auth-Token header parameter.
      *
-     * @param authHeader
+     * @param token
      *            a Fernet token
      * @return the secret information
      */

--- a/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/tokeninjection/TokenInjectionIT.java
+++ b/fernet-jersey-auth/src/test/java/com/macasaet/fernet/jersey/example/tokeninjection/TokenInjectionIT.java
@@ -53,7 +53,7 @@ public class TokenInjectionIT extends JerseyTest {
     @Test
     public final void verifySuccessfulBusinessRuleCheck() {
         // given
-        final LoginRequest login = new LoginRequest("alice", "1QYCGznPQ1z8T1aX_CNXKheDMAnNSfq_xnSxWXPLeKU=");
+        final LoginRequest login = new LoginRequest("alice", "frog washer kirtle gaily fipple clunch");
         final Entity<LoginRequest> entity = Entity.json(login);
         final String tokenString =  target("session").request().accept(MediaType.TEXT_PLAIN_TYPE).post(entity, String.class);
 
@@ -72,7 +72,7 @@ public class TokenInjectionIT extends JerseyTest {
     @Test
     public final void verifyFailedBusinessRuleCheck() {
         // given
-        final LoginRequest login = new LoginRequest("mallory", "Lpei3NWxhPsyc5NrJp6zkbHj4P_bji6Z7GsY0JSAUb8=");
+        final LoginRequest login = new LoginRequest("mallory", "puling nach abend wield xenium holmos");
         final Entity<LoginRequest> entity = Entity.json(login);
         final String tokenString =  target("session").request().accept(MediaType.TEXT_PLAIN_TYPE).post(entity, String.class);
 
@@ -91,7 +91,7 @@ public class TokenInjectionIT extends JerseyTest {
     @Test
     public final void verifyFailedLogin() {
         // given
-        final LoginRequest login = new LoginRequest("bob", "NReIudfT_iovLMo-MCX8sClVr3UwbeEhAq7er6X_Kps=");
+        final LoginRequest login = new LoginRequest("bob", "raia lehr import foehn read albata");
         final Entity<LoginRequest> entity = Entity.json(login);
 
         // when / then
@@ -130,18 +130,19 @@ public class TokenInjectionIT extends JerseyTest {
     @Test
     public final void verifyRevokedTokenUnusable() {
         // given
-        final LoginRequest login = new LoginRequest("alice", "1QYCGznPQ1z8T1aX_CNXKheDMAnNSfq_xnSxWXPLeKU=");
+        final LoginRequest login = new LoginRequest("alice", "frog washer kirtle gaily fipple clunch");
         final Entity<LoginRequest> entity = Entity.json(login);
         final String tokenString = target("session").request().accept(MediaType.TEXT_PLAIN_TYPE).post(entity,
                 String.class);
 
-        final Response revokeResponse = target("session").path("revocation").request(MediaType.TEXT_PLAIN_TYPE)
-                .put(Entity.text(tokenString));
-        assertEquals(204, revokeResponse.getStatus());
+        try(Response revokeResponse = target("session").path("revocation").request(MediaType.TEXT_PLAIN_TYPE)
+                .put(Entity.text(tokenString))) {
+            assertEquals(204, revokeResponse.getStatus());
 
-        // when / then
-        assertThrows(ForbiddenException.class,
-                () -> target("secrets").request().header("Authorization", "Bearer\t" + tokenString).get(String.class));
+            // when / then
+            assertThrows(ForbiddenException.class,
+                    () -> target("secrets").request().header("Authorization", "Bearer\t" + tokenString).get(String.class));
+        }
     }
 
     /**
@@ -151,7 +152,7 @@ public class TokenInjectionIT extends JerseyTest {
     @Test
     public final void verifyRenewedTokenUsable() {
         // given
-        final LoginRequest login = new LoginRequest("alice", "1QYCGznPQ1z8T1aX_CNXKheDMAnNSfq_xnSxWXPLeKU=");
+        final LoginRequest login = new LoginRequest("alice", "frog washer kirtle gaily fipple clunch");
         final String firstToken = target("session").request().accept(MediaType.TEXT_PLAIN_TYPE).post(Entity.json(login),
                 String.class);
         final String secondToken = target("session").path("renewal").request(MediaType.TEXT_PLAIN_TYPE)


### PR DESCRIPTION
In order to make the Jersey integration example more realistic and representative of authentication best practices, a key derivation function (Argon2id) is used instead of a simple hash.