### PR TITLE
Resolve SLF4J Warning in Unit Tests

### DIFF
--- a/fernet-java8/pom.xml
+++ b/fernet-java8/pom.xml
@@ -25,6 +25,16 @@
   <packaging>jar</packaging>
   <name>Fernet Java</name>
   <url>https://l0s.github.io/fernet-java8/${project.artifactId}</url>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <version>2.0.0</version>
+        <scope>test</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Resolve a build time warning due to an incompatibility between the `slf4j-api` and `logback-classic` versions.