### PR TITLE
Add contribution guidelines

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+the email address associated with this
+[PGP key](https://openpgpkey.carlos-m.net/.well-known/openpgpkey/carlos-m.net/hu/c13mpwjm93f4i3644xebt6gm64aqxenr).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing
+
+Thank you for your interest in participating in this project! 
+
+## Development Guidelines
+
+### Automated Testing
+
+When adding a new feature, please ensure it includes automated tests.
+When fixing bugs, please ensure at least one automated test reproduces
+the bug.
+
+For unit testing, the project must have at least 75% code coverage at
+all times and 75% mutation coverage at all times. These thresholds are
+programmatically enforced. If you feel they need to be relaxed, please
+explain your reasoning in the pull request.
+
+This project uses PITest to evaluate test coverage and test effectiveness.
+The latest report is available
+[here](https://l0s.github.io/fernet-java8/fernet-java8/pit-reports/index.html).
+To generate a report for a local build, run:
+
+    ./mvnw clean install site
+
+### Static Analysis
+
+This project uses
+[PMD](https://l0s.github.io/fernet-java8/fernet-java8/pmd.html)
+and [CodeQL](https://github.com/l0s/fernet-java8/security/code-scanning) for
+static analysis. Please do not circumvent these tools. If you feel a rule
+needs to be disabled or configured differently, please explain your
+reasoning in the pull request.
+
+## Development
+
+To build the project locally, run:
+
+    ./mvnw clean install
+
+To build using different JDK versions, use [jEnv](https://www.jenv.be/).
+
+### Releasing to The Central Repository
+
+This can only be done by the maintainer as it requires the appropriate
+Sonatype credentials and the PGP signing key.
+
+    ./mvnw --batch-mode -Prelease clean release:clean release:prepare release:perform
+
+## License
+
+   Copyright 2022 Carlos Macasaet
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and 
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -3,19 +3,20 @@
 [![Build Status](https://github.com/l0s/fernet-java8/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/l0s/fernet-java8/actions/workflows/ci.yml)
 [![Javadocs](https://javadoc.io/badge/com.macasaet.fernet/fernet-java8.svg)](https://javadoc.io/doc/com.macasaet.fernet/fernet-java8)
 [![Known Vulnerabilities](https://snyk.io/test/github/l0s/fernet-java8/badge.svg?targetFile=pom.xml)](https://snyk.io/test/github/l0s/fernet-java8?targetFile=pom.xml)
+[![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/6199/badge)](https://bestpractices.coreinfrastructure.org/projects/6199)
 
 This is an implementation of the
-[Fernet Spec](https://github.com/fernet/spec) using Java 8.
+[Fernet Spec](https://github.com/fernet/spec) using Java.
 The goal is to use only native Java constructs to avoid pulling in any
 dependencies so the library would be more generally usable. It also takes
-advantage of the Java 8 time objects to add type-safety.
+advantage of the Java time objects to add type-safety.
 
 I am actively soliciting feedback on this library. If you have any thoughts,
 please [submit an issue](https://github.com/l0s/fernet-java8/issues).
 
 ## Features
 * fully-validated against the scenarios in the [Fernet Spec](https://github.com/fernet/spec)
-* type-safety by using Java 8 time objects (no confusing milliseconds vs seconds after the epoch)
+* type-safety by using Java time objects (no confusing milliseconds vs seconds after the epoch)
 * no dependencies!
 * pluggable mechanism so you can specify your own:
     * Clock
@@ -126,17 +127,8 @@ It includes a Lambda Function to enable key rotation.
 
 ## Development
 
-### Mutation Testing and Test Coverage
-
-This project uses PITest to evaluate test coverage and test effectiveness.
-The latest report is available [here](https://l0s.github.io/fernet-java8/fernet-java8/pit-reports/index.html).
-To generate a report for a local build, run:
-
-    ./mvnw clean install site
-
-### Releasing to The Central Repository
-
-    ./mvnw --batch-mode -Prelease clean release:clean release:prepare release:perform
+See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to build this
+project.
 
 ## Prior Art
 


### PR DESCRIPTION
This adds guidelines for contributing to the project. It also adds a code of conduct and links to the OpenSSF Best Practices badge. Lastly, it deëmphasises Java 8 specifically as that is now the oldest supported available version.